### PR TITLE
[Components/Atoms] Icon 컴포넌트 구현

### DIFF
--- a/toronto/package.json
+++ b/toronto/package.json
@@ -7,6 +7,8 @@
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^13.0.0",
     "@testing-library/user-event": "^13.2.1",
+    "buffer": "^6.0.3",
+    "feather-icons": "^4.29.0",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
     "react-router-dom": "^6.3.0",

--- a/toronto/src/components/atoms/Icon/index.js
+++ b/toronto/src/components/atoms/Icon/index.js
@@ -1,0 +1,50 @@
+import styled from 'styled-components';
+import feather from 'feather-icons';
+import PropTypes from 'prop-types';
+import { Buffer } from 'buffer';
+
+const IconWrapper = styled.i`
+  display: inline-block;
+`;
+
+const Icon = ({
+  iconName,
+  size = 24,
+  strokeWidth = 1,
+  rotate = 0,
+  color = '#000',
+  ...props
+}) => {
+  const shapeStyle = {
+    width: size,
+    height: size,
+    transform: `rotate(${rotate}deg)`,
+  };
+
+  const iconStyle = {
+    'stroke-width': strokeWidth,
+    stroke: color,
+    width: size,
+    height: size,
+  };
+
+  const icon = feather.icons[iconName];
+  const svg = icon ? icon.toSvg(iconStyle) : '';
+  const base64 = Buffer.from(svg, 'utf8').toString('base64');
+
+  return (
+    <IconWrapper {...props} style={shapeStyle}>
+      <img src={`data:image/svg+xml; base64, ${base64}`} alt={iconName} />
+    </IconWrapper>
+  );
+};
+
+Icon.propTypes = {
+  iconName: PropTypes.string.isRequired,
+  size: PropTypes.number,
+  strokeWidth: PropTypes.number,
+  rotate: PropTypes.number,
+  color: PropTypes.string,
+};
+
+export default Icon;

--- a/toronto/src/stories/components/atoms/Icon.stories.js
+++ b/toronto/src/stories/components/atoms/Icon.stories.js
@@ -1,0 +1,19 @@
+import Icon from '@/components/atoms/Icon';
+
+export default {
+  title: 'Component/Icon',
+  component: Icon,
+  argTypes: {
+    size: { defaultValue: 24, control: { type: 'range', min: 16, max: 80 } },
+    strokeWidth: {
+      defaultValue: 1,
+      control: { type: 'range', min: 1, max: 3 },
+    },
+    color: { defaultValue: '#000', control: 'color' },
+    rotate: { defaultValue: 0, control: 'number' },
+  },
+};
+
+export const Default = (args) => {
+  return <Icon {...args} />;
+};

--- a/toronto/src/stories/components/atoms/Icon.stories.js
+++ b/toronto/src/stories/components/atoms/Icon.stories.js
@@ -4,6 +4,7 @@ export default {
   title: 'Component/Icon',
   component: Icon,
   argTypes: {
+    iconName: { defaultValue: 'github', control: 'text' },
     size: { defaultValue: 24, control: { type: 'range', min: 16, max: 80 } },
     strokeWidth: {
       defaultValue: 1,

--- a/toronto/yarn.lock
+++ b/toronto/yarn.lock
@@ -4567,7 +4567,7 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-base64-js@^1.0.2:
+base64-js@^1.0.2, base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
@@ -4864,6 +4864,14 @@ buffer@^4.3.0:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
     isarray "^1.0.0"
+
+buffer@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-6.0.3.tgz#2ace578459cc8fbe2a70aaa8f52ee63b6a74c6c6"
+  integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.2.1"
 
 builtin-modules@^3.1.0:
   version "3.3.0"
@@ -5196,6 +5204,11 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
+classnames@^2.2.5:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.1.tgz#dfcfa3891e306ec1dad105d0e88f4417b8535e8e"
+  integrity sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==
+
 clean-css@^4.2.3:
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.2.4.tgz#733bf46eba4e607c6891ea57c24a989356831178"
@@ -5509,7 +5522,7 @@ core-js-pure@^3.20.2, core-js-pure@^3.8.1:
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.22.8.tgz#f2157793b58719196ccf9673cc14f3683adc0957"
   integrity sha512-bOxbZIy9S5n4OVH63XaLVXZ49QKicjowDx/UELyJ68vxfCRpYsbyh/WNZNfEfAk+ekA8vSjt+gCDpvh672bc3w==
 
-core-js@^3.0.4, core-js@^3.19.2, core-js@^3.6.5, core-js@^3.8.2:
+core-js@^3.0.4, core-js@^3.1.3, core-js@^3.19.2, core-js@^3.6.5, core-js@^3.8.2:
   version "3.22.8"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.22.8.tgz#23f860b1fe60797cc4f704d76c93fea8a2f60631"
   integrity sha512-UoGQ/cfzGYIuiq6Z7vWL1HfkE9U9IZ4Ub+0XSiJTCzvbZzgPA69oDF2f+lgJ6dFFLEdjW5O6svvoKzXX23xFkA==
@@ -7043,6 +7056,14 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
+feather-icons@^4.29.0:
+  version "4.29.0"
+  resolved "https://registry.yarnpkg.com/feather-icons/-/feather-icons-4.29.0.tgz#4e40e3cbb7bf359ffbbf700edbebdde4e4a74ab6"
+  integrity sha512-Y7VqN9FYb8KdaSF0qD1081HCkm0v4Eq/fpfQYQnubpqi0hXx14k+gF9iqtRys1SIcTEi97xDi/fmsPFZ8xo0GQ==
+  dependencies:
+    classnames "^2.2.5"
+    core-js "^3.1.3"
+
 fetch-retry@^5.0.2:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/fetch-retry/-/fetch-retry-5.0.2.tgz#4c55663a7c056cb45f182394e479464f0ff8f3e3"
@@ -8045,7 +8066,7 @@ identity-obj-proxy@^3.0.0:
   dependencies:
     harmony-reflect "^1.4.6"
 
-ieee754@^1.1.4:
+ieee754@^1.1.4, ieee754@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==


### PR DESCRIPTION
## 구현 
[feather-icons](https://feathericons.com/) 라이브러리를 이용한 Icon 컴포넌트 구현

강의 시간에 사용했던 Icon 컴포넌트 내용을 베이스로, propTypes 추가 및 import와 혼재되어 있던 `CommonJS` 방식의 module import 를 `ES6` import로 변경

## props

- **iconName*** 사용할 icon의 이름
- **size**: icon의 크기
- **strokeWidth**: icon을 구성하는 선의 굵기
- **rotate**: icon의 회전 각도
- **color**: icon의 색상

## storybook
![image](https://user-images.githubusercontent.com/62253743/172782998-0852b2ed-5530-46d6-b7e2-afeff891bd94.png)

