### PR TITLE
[Components/Atoms] Icon 컴포넌트 fill prop 추가

### DIFF
--- a/toronto/src/components/atoms/Icon/index.js
+++ b/toronto/src/components/atoms/Icon/index.js
@@ -13,6 +13,7 @@ const Icon = ({
   strokeWidth = 1,
   rotate = 0,
   color = '#000',
+  fill = '#fff',
   ...props
 }) => {
   const shapeStyle = {
@@ -26,6 +27,7 @@ const Icon = ({
     stroke: color,
     width: size,
     height: size,
+    fill,
   };
 
   const icon = feather.icons[iconName];
@@ -33,7 +35,7 @@ const Icon = ({
   const base64 = Buffer.from(svg, 'utf8').toString('base64');
 
   return (
-    <IconWrapper {...props} style={shapeStyle}>
+    <IconWrapper {...props} style={{ ...props.style, ...shapeStyle }}>
       <img src={`data:image/svg+xml; base64, ${base64}`} alt={iconName} />
     </IconWrapper>
   );
@@ -45,6 +47,7 @@ Icon.propTypes = {
   strokeWidth: PropTypes.number,
   rotate: PropTypes.number,
   color: PropTypes.string,
+  fill: PropTypes.string,
 };
 
 export default Icon;

--- a/toronto/src/stories/components/atoms/Icon.stories.js
+++ b/toronto/src/stories/components/atoms/Icon.stories.js
@@ -11,6 +11,7 @@ export default {
       control: { type: 'range', min: 1, max: 3 },
     },
     color: { defaultValue: '#000', control: 'color' },
+    fill: { defaultValue: '#fff', control: 'color' },
     rotate: { defaultValue: 0, control: 'number' },
   },
 };


### PR DESCRIPTION
## 구현
Icon의 빈 공간에 색을 채워넣을 수 있도록 `fill` prop을 추가했습니다.

## props
**fill**: 채워넣을 색상을 string 형태로 선언

## storybook
![Icon_Component](https://user-images.githubusercontent.com/62253743/172874911-ac2ceaee-f340-4158-9fc5-d8203a4c61e2.gif)
