### PR TITLE
[Components/Atoms] Card 컴포넌트 구현

### DIFF
--- a/toronto/src/components/atoms/Card/index.js
+++ b/toronto/src/components/atoms/Card/index.js
@@ -48,11 +48,11 @@ const Card = ({
 
 Card.propTypes = {
   children: PropTypes.node.isRequired,
-  padding: PropTypes.number,
+  padding: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   hover: PropTypes.bool,
   shadow: PropTypes.bool,
   color: PropTypes.string,
-  radius: PropTypes.number,
+  radius: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 export default Card;

--- a/toronto/src/components/atoms/Card/index.js
+++ b/toronto/src/components/atoms/Card/index.js
@@ -39,7 +39,6 @@ const Card = ({
       color={color}
       radius={radius}
       shadow={shadow}
-      style={{ ...props.style }}
     >
       {children}
     </CardContainer>

--- a/toronto/src/components/atoms/Card/index.js
+++ b/toronto/src/components/atoms/Card/index.js
@@ -1,4 +1,5 @@
 import styled, { css } from 'styled-components';
+import PropTypes from 'prop-types';
 
 const CardContainer = styled.div`
   display: inline-block;
@@ -43,6 +44,15 @@ const Card = ({
       {children}
     </CardContainer>
   );
+};
+
+Card.propTypes = {
+  children: PropTypes.node.isRequired,
+  padding: PropTypes.number,
+  hover: PropTypes.bool,
+  shadow: PropTypes.bool,
+  color: PropTypes.string,
+  radius: PropTypes.number,
 };
 
 export default Card;

--- a/toronto/src/components/atoms/Card/index.js
+++ b/toronto/src/components/atoms/Card/index.js
@@ -1,0 +1,48 @@
+import styled, { css } from 'styled-components';
+
+const CardContainer = styled.div`
+  display: inline-block;
+  padding: ${({ padding }) =>
+    typeof padding === 'number' ? `${padding}px` : padding};
+  box-shadow: ${({ shadow }) =>
+    shadow &&
+    `rgba(50, 50, 93, 0.25) 0px 6px 12px -2px,
+    rgba(0, 0, 0, 0.3) 0px 3px 7px -3px`};
+  background-color: ${({ color }) => color};
+  border-radius: ${({ radius }) =>
+    typeof radius === 'number' ? `${radius}px` : radius};
+  ${({ hover }) =>
+    hover &&
+    css`
+      &:hover {
+        transform: scale(1.05);
+        transition: transform 0.3s ease-out;
+      }
+    `};
+`;
+
+const Card = ({
+  children,
+  padding,
+  hover = false,
+  shadow = true,
+  color = '#fff',
+  radius = 5,
+  ...props
+}) => {
+  return (
+    <CardContainer
+      {...props}
+      padding={padding}
+      hover={hover}
+      color={color}
+      radius={radius}
+      shadow={shadow}
+      style={{ ...props.style }}
+    >
+      {children}
+    </CardContainer>
+  );
+};
+
+export default Card;

--- a/toronto/src/stories/components/atoms/Card.stories.js
+++ b/toronto/src/stories/components/atoms/Card.stories.js
@@ -1,0 +1,44 @@
+import Card from '@/components/atoms/Card';
+import Header from '@/components/atoms/Header';
+import Text from '@/components/atoms/Text';
+import Image from '@/components/atoms/Image';
+import styled from 'styled-components';
+
+export default {
+  title: 'Component/Card',
+  component: Card,
+  argTypes: {
+    padding: { defaultValue: 10, control: 'number' },
+    hover: { defaultValue: false, control: 'boolean' },
+    shadow: { defaultValue: true, control: 'boolean' },
+    color: { defaultValue: '#fff', control: 'color' },
+    radius: { defaultValue: 5, control: 'number' },
+  },
+};
+
+const Wrapper = styled.div`
+  width: 300px;
+  height: 300px;
+`;
+
+export const Default = (args) => {
+  return (
+    <Card {...args}>
+      <Header>PostTitle</Header>
+      <Image src="https://picsum.photos/200" />
+      <Text style={{ display: 'block' }}>PostContent</Text>
+    </Card>
+  );
+};
+
+export const Wrap = (args) => {
+  return (
+    <Card {...args}>
+      <Wrapper>
+        <Header>PostTitle</Header>
+        <Image src="https://picsum.photos/200" width={'100%'} height={200} />
+        <Text style={{ display: 'block' }}>PostContent</Text>
+      </Wrapper>
+    </Card>
+  );
+};


### PR DESCRIPTION
## 구현
여러 컴포넌트의 `Wrapper` 역할을 하는 Card 컴포넌트 구현

## Props
- **children***: Card 컴포넌트의 자식 요소
- **padding**: Card 컴포넌트의 패딩 값, // `string, number`
- **hover**: Card에 마우스 오버 시 transform 여부 // `boolean` 
- **shadow**: Card의 box-shadow 여부 // `boolean`
- **color**: Card의 배경 색 지정 // `string`
- **radius**: Card의 border-radius 지정 // `string, number`

## UI
![image](https://user-images.githubusercontent.com/62253743/173025987-4157ab9c-0466-4cc3-b176-7da23cadf6b6.png)

## 주의사항

`Card`의 자식 요소들의 위치를 제어하고 싶으시다면, 아래처럼 내부에 `styled-component`를 이용해서 한번 더 감싸주시고 배치하시면 됩니다.
![image](https://user-images.githubusercontent.com/62253743/173026436-9b667509-a13f-48a0-93aa-aae6c5268a55.png)


