### PR TITLE
[Components/Atoms] Avatar 컴포넌트 추가

### DIFF
--- a/toronto/src/components/atoms/Avatar/index.js
+++ b/toronto/src/components/atoms/Avatar/index.js
@@ -1,4 +1,5 @@
 import ImageComponent from '../Image';
+import AvatarGroup from '../../molecules/AvatarGroup';
 import styled from 'styled-components';
 import { useState, useEffect } from 'react';
 
@@ -29,6 +30,7 @@ const Avatar = ({
   placeholder,
   alt,
   mode = 'dover',
+  __TYPE,
   ...props
 }) => {
   const [loaded, setLoaded] = useState(false);
@@ -55,5 +57,11 @@ const Avatar = ({
     </AvatarWrapper>
   );
 };
+
+Avatar.defaultProps = {
+  __TYPE: 'Avatar',
+};
+
+Avatar.Group = AvatarGroup;
 
 export default Avatar;

--- a/toronto/src/components/atoms/Avatar/index.js
+++ b/toronto/src/components/atoms/Avatar/index.js
@@ -1,12 +1,12 @@
-import ImageComponent from '../Image';
-import AvatarGroup from '../../molecules/AvatarGroup';
+import ImageComponent from '@/components/atoms/Image';
+import AvatarGroup from '@/components/molecules/AvatarGroup';
 import styled from 'styled-components';
 import { useState, useEffect } from 'react';
 
 const ShapeToCssValue = {
   circle: '50%',
   round: '4px',
-  sqare: '0px',
+  square: '0px',
 };
 
 const AvatarWrapper = styled.div`

--- a/toronto/src/components/atoms/Avatar/index.js
+++ b/toronto/src/components/atoms/Avatar/index.js
@@ -1,0 +1,59 @@
+import ImageComponent from '../Image';
+import styled from 'styled-components';
+import { useState, useEffect } from 'react';
+
+const ShapeToCssValue = {
+  circle: '50%',
+  round: '4px',
+  sqare: '0px',
+};
+
+const AvatarWrapper = styled.div`
+  position: relative;
+  display: inline-block;
+  border: 1px solid #dadada;
+  border-radius: ${({ shape }) => ShapeToCssValue[shape]};
+  background-color: #eee;
+  overflow: hidden;
+  > img {
+    transition: opacity 0.3s ease-out;
+  }
+`;
+
+const Avatar = ({
+  lazy,
+  threshold,
+  src,
+  size = 70,
+  shape = 'circle',
+  placeholder,
+  alt,
+  mode = 'dover',
+  ...props
+}) => {
+  const [loaded, setLoaded] = useState(false);
+  useEffect(() => {
+    const image = new Image();
+    image.src = src;
+    image.onload = () => setLoaded(true);
+  }, [src]);
+
+  return (
+    <AvatarWrapper {...props} shape={shape}>
+      <ImageComponent
+        block
+        lazy={lazy}
+        threshold={threshold}
+        width={size}
+        height={size}
+        src={src}
+        placeholder={placeholder}
+        alt={alt}
+        mode={mode}
+        style={{ opacity: loaded ? 1 : 0 }}
+      />
+    </AvatarWrapper>
+  );
+};
+
+export default Avatar;

--- a/toronto/src/components/molecules/AvatarGroup/index.js
+++ b/toronto/src/components/molecules/AvatarGroup/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-const AvatarGroup = ({ children, shape = 'circle', size = 70, ...props }) => {
+const AvatarGroup = ({ children, shape = 'circle', size = 70 }) => {
   const avatars = React.Children.toArray(children)
     .filter((element) => {
       if (React.isValidElement(element) && element.props.__TYPE === 'Avatar') {

--- a/toronto/src/components/molecules/AvatarGroup/index.js
+++ b/toronto/src/components/molecules/AvatarGroup/index.js
@@ -1,0 +1,27 @@
+import React from 'react';
+
+const AvatarGroup = ({ children, shape = 'circle', size = 70, ...props }) => {
+  const avatars = React.Children.toArray(children)
+    .filter((element) => {
+      if (React.isValidElement(element) && element.props.__TYPE === 'Avatar') {
+        return true;
+      }
+      return false;
+    })
+    .map((avatar, index, avatars) => {
+      return React.cloneElement(avatar, {
+        ...avatar.props,
+        size,
+        shape,
+        style: {
+          ...avatar.props,
+          marginLeft: -size / 5,
+          zIndex: avatars.length - index,
+        },
+      });
+    });
+
+  return <div style={{ paddingLeft: size / 5 }}>{avatars}</div>;
+};
+
+export default AvatarGroup;

--- a/toronto/src/stories/components/atoms/Avatar.stories.js
+++ b/toronto/src/stories/components/atoms/Avatar.stories.js
@@ -1,0 +1,25 @@
+import Avatar from '@/components/atoms/Avatar';
+
+export default {
+  title: 'Component/Avatar',
+  component: 'Avatar',
+  argTypes: {
+    src: { defaultValue: 'https://picsum.photos/200' },
+    shape: {
+      defaultValue: 'circle',
+      control: 'inline-radio',
+      options: ['circle', 'round', 'square'],
+    },
+    size: {
+      defaultValue: 70,
+      control: { type: 'range', min: 40, max: 200 },
+    },
+    mode: {
+      defaultValue: 'cover',
+      control: 'inline-radio',
+      options: ['contain', 'cover', 'fill'],
+    },
+  },
+};
+
+export const Default = (args) => <Avatar {...args} />;

--- a/toronto/src/stories/components/atoms/Avatar.stories.js
+++ b/toronto/src/stories/components/atoms/Avatar.stories.js
@@ -23,3 +23,14 @@ export default {
 };
 
 export const Default = (args) => <Avatar {...args} />;
+
+export const Group = () => {
+  return (
+    <Avatar.Group size={40}>
+      <Avatar src='https://picsum.photos/200' />
+      <Avatar src='https://picsum.photos/300' />
+      <Avatar src='https://picsum.photos/400' />
+      <Avatar src='https://picsum.photos/500' />
+    </Avatar.Group>
+  );
+};


### PR DESCRIPTION
## 📌 과제 설명
- Avatar, Avatar Group 컴포넌트 구현

## 👩‍💻 요구 사항과 구현 내용
Avatar
<img width="100" alt="Avatar" src="https://user-images.githubusercontent.com/33307948/173105208-904900eb-b152-460f-a2fb-6404572d3d73.png">
- 사용자 페이지에 사용할 Avatar 구현했습니다!
- shape 옵션으로 circle, round, square 사용할 수 있습니다.
- size 조절이 가능합니다.
- mode 옵션으로 contain, cover, fill 사용할 수 있습니다.

Avatar Group
<img width="187" alt="AvatarGroup" src="https://user-images.githubusercontent.com/33307948/173105236-2dead65f-78bc-4a1c-be25-0e14bde665c5.png">

- 활동 중인 사용자나 가입자 목록에 사용할 수도 있을 것 같아 같이 올립니다!
- Group 같은 경우 size를 40으로 고정해뒀습니다. 추후 수정해서 사용하면 될 것 같습니다.
