### PR TITLE
[Components/Organisms] PostList 컴포넌트 구현

### DIFF
--- a/toronto/src/components/organisms/PostList/index.js
+++ b/toronto/src/components/organisms/PostList/index.js
@@ -1,0 +1,22 @@
+import styled from 'styled-components';
+import PostItem from '@/components/molecules/PostItem';
+
+const GridContainer = styled.ul`
+  display: grid;
+  padding: 0;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  grid-template-rows: repeat(auto-fit, minmax(300px, 1fr));
+  grid-gap: 30px;
+`;
+
+const PostList = ({ posts }) => {
+  return (
+    <GridContainer>
+      {posts.map((post) => (
+        <PostItem key={post._id} post={post} />
+      ))}
+    </GridContainer>
+  );
+};
+
+export default PostList;

--- a/toronto/src/stories/components/organisms/PostList.stories.js
+++ b/toronto/src/stories/components/organisms/PostList.stories.js
@@ -1,0 +1,46 @@
+import PostList from '@/components/organisms/PostList';
+import { BrowserRouter } from 'react-router-dom';
+
+export default {
+  title: 'Component/organisms/PostList',
+  component: PostList,
+};
+
+const posts = [
+  {
+    likes: [{ user: '62a6c351f1f0277287103588' }],
+    _id: '62a75a3f4ed95908dae3b5a4',
+    title:
+      '{ "postTitle": "좋아요 테스트용 게시물", "postContent": "대충 내용"}',
+    image: 'https://picsum.photos/200',
+  },
+  {
+    likes: [],
+    _id: '62a82858b63ef01e9c9e784d',
+    title:
+      '{ "postTitle": "좋아요 테스트용 게시물", "postContent": "대충 내용"}',
+    image: 'https://picsum.photos/200',
+  },
+  {
+    likes: [],
+    _id: '62a8282cb63ef01e9c9e7847',
+    title:
+      '{ "postTitle": "좋아요 테스트용 게시물", "postContent": "대충 내용"}',
+    image: 'https://picsum.photos/200',
+  },
+  {
+    likes: [{ user: '62a6c351f1f0277287103588' }],
+    _id: '62a8281db63ef01e9c9e7841',
+    title:
+      '{ "postTitle": "좋아요 테스트용 게시물", "postContent": "대충 내용"}',
+    image: 'https://picsum.photos/200',
+  },
+];
+
+export const Default = () => {
+  return (
+    <BrowserRouter>
+      <PostList posts={posts} />
+    </BrowserRouter>
+  );
+};


### PR DESCRIPTION
## 구현 내용

`posts` prop을 기반으로 `PostItem` 컴포넌트를 `grid` 형태로 그려주는 컴포넌트 구현

<br>

## props

- posts: 배열 형태의 포스트 목록

<br>

## Storybook

![image](https://user-images.githubusercontent.com/62253743/173637286-740ed97e-188f-449b-b1a2-d90740be9161.png)

<br>

## 주의사항

기존 `PostItem`에 있던 좋아요 관련 `API` 는 서버 다운 이슈(추측)로 일단 모두 삭제한 뒤 `develop`에 `push`해둔 상태입니다.

따라서 **기존 `PostItem`의 로직은 절대로 실행시키지 않는것을 권장**드리며, **현재 PR에 사용된 `PostItem`은 `API` 연동이 제거된 상태**이므로 `storybook`에서 좋아요 버튼을 클릭하면 UI가 정상적으로 toggle되는 것을 확인하실 수 있습니다.

