### PR TITLE
[Pages/UserProfile]  UserProfilePage 좋아요 게시글 기능 구현

### DIFF
--- a/toronto/src/api/Api.js
+++ b/toronto/src/api/Api.js
@@ -7,7 +7,7 @@ export const postLoginApi = async ({ email, password }) => {
     email,
     password,
   });
-  onSaveToken(res.data.token); //save token in cookie
+  onSaveToken(res.data.token);
   return res;
 };
 
@@ -49,7 +49,6 @@ export const getUserApi = async (userId) => {
 // 프로필 이미지 변경 및 커버 이미지 변경
 export const postUploadPhotoApi = async (bodyFormData) => {
   const token = getToken();
-  console.log(token);
   const res = await axios({
     method: 'post',
     url: `${process.env.REACT_APP_END_POINT}/users/upload-photo`,
@@ -80,3 +79,33 @@ export const putUpdatePasswordApi = async (password) => {
 };
 
 // TODO: 채널부터 추가
+
+// EditProfile 내 게시물 임시 더미데이터 API
+export const getUserPostApi = async () => {
+  const res = await axios.get('/data/postDummy.json');
+  return res;
+};
+
+// EditProfile 좋아요 게시물 임시 더미데이터 API
+export const getUserDummyApi = async () => {
+  const res = await axios.get('/data/userDummy.json');
+  return res;
+};
+
+// 채널 목록 불러오기
+export const getChannels = async () => {
+  const res = await Send.get('/channels');
+  return res;
+};
+
+// 특정 채널 목록 불러오기
+export const getChannelsName = async (channelName) => {
+  const res = await Send.get(`/channels/${channelName}`);
+  return res;
+};
+
+// 특정 채널의 포스트 목록
+export const getPostsChannel = async (channelId) => {
+  const res = await Send.get(`posts/channel/${channelId}`);
+  return res;
+};

--- a/toronto/src/pages/UserProfile.jsx
+++ b/toronto/src/pages/UserProfile.jsx
@@ -26,7 +26,6 @@ const UserProfile = () => {
 
       // 특정 사용자의 User 객체
       const userDummy = await getUserDummyApi();
-      console.log(userDummy);
       const userLikesPostsId = userDummy.data.likes.map((like) => like.post);
 
       // 특정 채널의 전체 Post 배열
@@ -41,9 +40,6 @@ const UserProfile = () => {
     };
     fetchData();
   }, []);
-  // console.log('postsDummy: ', postsDummy);
-  // console.log('userDummy: ', userDummy);
-  // console.log('channelPosts', channelPosts);
 
   //전체 posts 중에서 id값이 userLikesPostsId인 값이 속하는지 판단해서 return post
   if (loading) return <Loader type='spinner' />;

--- a/toronto/src/pages/UserProfile.jsx
+++ b/toronto/src/pages/UserProfile.jsx
@@ -8,16 +8,44 @@ import {
   Loader,
 } from '@/components/atoms';
 import Tab from '@/components/molecules/Tab';
-
-import {
-  // getUser,
-  useUsersState,
-} from '../contexts/UserContext.js';
+import PostList from '@/components/organisms/PostList';
+import { useUsersState } from '@/contexts/UserContext.js';
+import { getUserPostApi, getUserDummyApi, getPostsChannel } from '@/api/Api';
+import { useState, useEffect } from 'react';
 
 const UserProfile = () => {
   const state = useUsersState();
   const { data: user, loading, error } = state.user;
+  const [postsDummy, setPostsDummy] = useState([]);
+  const [likesPosts, setLikesPosts] = useState([]);
 
+  useEffect(() => {
+    const fetchData = async () => {
+      // 특정 사용자의 User 객체의 posts key에 해당하는 Post[]
+      const postsDummy = await getUserPostApi();
+
+      // 특정 사용자의 User 객체
+      const userDummy = await getUserDummyApi();
+      console.log(userDummy);
+      const userLikesPostsId = userDummy.data.likes.map((like) => like.post);
+
+      // 특정 채널의 전체 Post 배열
+      const channelId = postsDummy.data.posts[0].channel._id;
+      const channelPosts = await getPostsChannel(channelId);
+
+      const likePosts = channelPosts.data.filter((post) =>
+        userLikesPostsId.includes(post._id),
+      );
+      setPostsDummy(postsDummy.data.posts);
+      setLikesPosts(likePosts);
+    };
+    fetchData();
+  }, []);
+  // console.log('postsDummy: ', postsDummy);
+  // console.log('userDummy: ', userDummy);
+  // console.log('channelPosts', channelPosts);
+
+  //전체 posts 중에서 id값이 userLikesPostsId인 값이 속하는지 판단해서 return post
   if (loading) return <Loader type='spinner' />;
   if (error) return <div>에러가 발생했습니다</div>;
   if (!user) {
@@ -44,12 +72,12 @@ const UserProfile = () => {
           </ProfileSection>
           <Tab>
             <Tab.Item title='내 게시물' index='item1'>
-              <Header>내 게시물</Header>
-              <Text>{user.posts}</Text>
+              {/* TODO: User 객체에 포스트를 작성 후  */}
+              {/* {user.posts ? <PostList posts={user.posts} /> : []} */}
+              {postsDummy ? <PostList posts={postsDummy} /> : []}
             </Tab.Item>
             <Tab.Item title='좋아요 게시물' index='item2'>
-              <Header>좋아요 게시물</Header>
-              <Text>{user.likes}</Text>
+              <PostList posts={likesPosts} />
             </Tab.Item>
           </Tab>
         </Wrapper>
@@ -64,6 +92,7 @@ const ContentWrapper = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
+  width: 100%;
   height: 80vh;
   background-color: #f9fafb;
 `;


### PR DESCRIPTION
## 📌 과제 설명
- 유저프로필 페이지 좋아요 게시글 기능을 더미데이터로 구현을 완료했습니다!

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
### 페이지
<img width="1792" alt="내 게시물 탭" src="https://user-images.githubusercontent.com/33307948/174422648-ef95d010-c070-4d70-b47a-eff6312c0fb9.png">

<img width="1792" alt="좋아요 게시물 탭" src="https://user-images.githubusercontent.com/33307948/174422683-cd473759-7986-4439-9104-f2a66ed4c686.png">

### API 연동
[feat(Api): 채널 Api 추가](https://github.com/prgrms-fe-devcourse/FEDC2_ToronTo_Nayoung/commit/3a728504209fa5cb857ca2ef6a9834a986f6b7d7)
- 내 게시물을 받아오기 위해서 User객체의 post 배열이 필요한데 현재 오류인 상태로 알고 있어 더미 데이터로 구현해뒀습니다. 이 부분은 추후 글쓰기를 통해 내 게시물을 쓴 후 변경해 두도록 하겠습니다.
- 좋아요 게시물을 가지고 오기 위해서 User 객체의 likes에 있는 post id와 특정 채널의 포스트 목록의 id를 비교하기 위해 특정 채널의 포스트 목록 조회 API를 연동했습니다.

[feat(UserProfilePage): 좋아요 게시물 구현](https://github.com/prgrms-fe-devcourse/FEDC2_ToronTo_Nayoung/commit/93a57978ead09b4a378a41fcc2d0cbe21ce26338)
- 좋아요 게시물을 가지고 오기 위해서 User 객체의 likes에 있는 post id와 전체 채널의 포스트 목록의 id를 비교하여 좋아요 post를 뿌려줬습니다.

[refactor(UserProfilePage): 불필요한 주석 제거](https://github.com/prgrms-fe-devcourse/FEDC2_ToronTo_Nayoung/commit/7e4a3bec924c9e01153e850a24fa4f263308eaa0)

