### PR TITLE
[Context/UserContext] Login 유지, Logout 기능 구현, SignUp API 연동

### DIFF
--- a/toronto/src/api/Api.js
+++ b/toronto/src/api/Api.js
@@ -17,6 +17,7 @@ export const postSignUpApi = async ({ email, fullName, password }) => {
     fullName,
     password,
   });
+  onSaveToken(res.data.token);
   return res;
 };
 

--- a/toronto/src/api/Api.js
+++ b/toronto/src/api/Api.js
@@ -25,7 +25,7 @@ export const getAuthUser = async () => {
   return res;
 };
 
-export const postLogout = async () => {
+export const postLogoutApi = async () => {
   const res = await Send.post('/logout');
   return res;
 };

--- a/toronto/src/components/organisms/LoginForm/index.js
+++ b/toronto/src/components/organisms/LoginForm/index.js
@@ -1,13 +1,12 @@
 import styled from 'styled-components';
-import Text from '@/components/atoms/Text';
-import Button from '@/components/atoms/Button';
+import { Text, Button, Loader } from '@/components/atoms/';
 import FormField from '@/components/molecules/FormField';
 import useForm from '@/hooks/useForm';
 import {
   postLogin,
   useUsersDispatch,
   useUsersState,
-} from '../../../contexts/UserContext.js';
+} from '@/contexts/UserContext.js';
 import { useNavigate } from 'react-router-dom';
 
 const CardForm = styled.form`
@@ -51,7 +50,7 @@ const LoginForm = () => {
     },
   });
 
-  if (loading) return <div>로딩중..</div>;
+  if (loading) return <Loader type='spinner' />;
   if (error) return <div>에러가 발생했습니다</div>;
   if (!user) {
     return (
@@ -82,7 +81,7 @@ const LoginForm = () => {
     );
   }
   if (user) {
-    return <Text>로그인 Navigation을 Logout으로 변경</Text>;
+    return <Text>유저 객체가 있습니다 처리가 필요합니다!</Text>;
   }
 };
 

--- a/toronto/src/components/organisms/SignUpForm/index.js
+++ b/toronto/src/components/organisms/SignUpForm/index.js
@@ -1,9 +1,13 @@
 import styled from 'styled-components';
-import Text from '@/components/atoms/Text';
-import Button from '@/components/atoms/Button';
+import { Text, Button, Loader } from '@/components/atoms/';
 import FormField from '@/components/molecules/FormField';
 import useForm from '@/hooks/useForm';
-import { requestApi } from '@/api';
+import {
+  useUsersDispatch,
+  useUsersState,
+  postSignUp,
+} from '@/contexts/UserContext.js';
+import { useNavigate } from 'react-router-dom';
 
 const CardForm = styled.form`
   padding: 7% 14%;
@@ -16,6 +20,11 @@ const CardForm = styled.form`
 `;
 
 const SignUpForm = () => {
+  const state = useUsersState();
+  const dispatch = useUsersDispatch();
+  const { data: user, loading, error } = state.user;
+  const navigate = useNavigate();
+
   const { errors, isLoading, handleChange, handleSubmit } = useForm({
     initialValues: {
       name: '',
@@ -24,16 +33,17 @@ const SignUpForm = () => {
       passwordConfirm: '',
     },
     onSubmit: async (values) => {
-      const res = await requestApi('/signup', {
-        method: 'POST',
-        data: {
-          email: values.email,
-          fullName: values.name,
-          password: values.password,
-        },
-      });
-      if (res) alert('회원가입 되었습니다.');
-      else alert('회원가입 되지 않았습니다.');
+      const res = await postSignUp(
+        dispatch,
+        values.email,
+        values.name,
+        values.password,
+      );
+      if (res) {
+        navigate('/');
+      } else {
+        navigate('/sign-up');
+      }
     },
     validate: ({ name, email, password, passwordConfirm }) => {
       const newErrors = {};
@@ -51,49 +61,52 @@ const SignUpForm = () => {
       return newErrors;
     },
   });
-
-  return (
-    <CardForm onSubmit={handleSubmit}>
-      <Text strong style={{ marginBottom: '32px' }}>
-        회원가입
-      </Text>
-      <FormField
-        textTitle='성명'
-        inputType='text'
-        inputName='name'
-        inputPlaceholder='성명'
-        inputOnChange={handleChange}
-        textError={errors.name}
-      />
-      <FormField
-        textTitle='이메일'
-        inputType='email'
-        inputName='email'
-        inputPlaceholder='이메일'
-        inputOnChange={handleChange}
-        textError={errors.email}
-      />
-      <FormField
-        textTitle='비밀번호'
-        inputType='password'
-        inputName='password'
-        inputPlaceholder='비밀번호'
-        inputOnChange={handleChange}
-        textError={errors.password}
-      />
-      <FormField
-        textTitle='비밀번호 확인'
-        inputType='password'
-        inputName='passwordConfirm'
-        inputPlaceholder='비밀번호 확인'
-        inputOnChange={handleChange}
-        textError={errors.passwordConfirm}
-      />
-      <Button disabled={isLoading} style={{ marginTop: '32px' }}>
-        회원가입
-      </Button>
-    </CardForm>
-  );
+  if (loading) return <Loader type='spinner' />;
+  if (error) return <div>에러가 발생했습니다</div>;
+  if (!user) {
+    return (
+      <CardForm onSubmit={handleSubmit}>
+        <Text strong style={{ marginBottom: '32px' }}>
+          회원가입
+        </Text>
+        <FormField
+          textTitle='성명'
+          inputType='text'
+          inputName='name'
+          inputPlaceholder='성명'
+          inputOnChange={handleChange}
+          textError={errors.name}
+        />
+        <FormField
+          textTitle='이메일'
+          inputType='email'
+          inputName='email'
+          inputPlaceholder='이메일'
+          inputOnChange={handleChange}
+          textError={errors.email}
+        />
+        <FormField
+          textTitle='비밀번호'
+          inputType='password'
+          inputName='password'
+          inputPlaceholder='비밀번호'
+          inputOnChange={handleChange}
+          textError={errors.password}
+        />
+        <FormField
+          textTitle='비밀번호 확인'
+          inputType='password'
+          inputName='passwordConfirm'
+          inputPlaceholder='비밀번호 확인'
+          inputOnChange={handleChange}
+          textError={errors.passwordConfirm}
+        />
+        <Button disabled={isLoading} style={{ marginTop: '32px' }}>
+          회원가입
+        </Button>
+      </CardForm>
+    );
+  }
 };
 
 export default SignUpForm;

--- a/toronto/src/contexts/UserContext.js
+++ b/toronto/src/contexts/UserContext.js
@@ -19,7 +19,7 @@ const initialState = {
   user: initialAsyncState,
 };
 
-const singUpHandler = createAsyncHandler('POST_SIGNUP', 'user');
+const signUpHandler = createAsyncHandler('POST_SIGNUP', 'user');
 const usersHandler = createAsyncHandler('GET_USERS', 'users');
 const userHandler = createAsyncHandler('GET_USER', 'user');
 const loginHandler = createAsyncHandler('POST_LOGIN', 'user');
@@ -36,7 +36,7 @@ const usersReducer = (state, action) => {
     case 'POST_SIGNUP':
     case 'POST_SIGNUP_SUCCESS':
     case 'POST_SIGNUP_ERROR':
-      return singUpHandler(state, action);
+      return signUpHandler(state, action);
     case 'GET_USERS':
     case 'GET_USERS_SUCCESS':
     case 'GET_USERS_ERROR':

--- a/toronto/src/contexts/UserContext.js
+++ b/toronto/src/contexts/UserContext.js
@@ -1,5 +1,6 @@
 import React, { createContext, useReducer, useContext } from 'react';
 import {
+  postSignUpApi,
   getUsersApi,
   getUserApi,
   postLoginApi,
@@ -18,6 +19,7 @@ const initialState = {
   user: initialAsyncState,
 };
 
+const singUpHandler = createAsyncHandler('POST_SIGNUP', 'user');
 const usersHandler = createAsyncHandler('GET_USERS', 'users');
 const userHandler = createAsyncHandler('GET_USER', 'user');
 const loginHandler = createAsyncHandler('POST_LOGIN', 'user');
@@ -31,6 +33,10 @@ const uploadProfileImageHandler = createAsyncHandler(
 
 const usersReducer = (state, action) => {
   switch (action.type) {
+    case 'POST_SIGNUP':
+    case 'POST_SIGNUP_SUCCESS':
+    case 'POST_SIGNUP_ERROR':
+      return singUpHandler(state, action);
     case 'GET_USERS':
     case 'GET_USERS_SUCCESS':
     case 'GET_USERS_ERROR':
@@ -97,6 +103,22 @@ export const useUsersDispatch = () => {
   return dispatch;
 };
 
+// postSignUpAPI 연동
+export async function postSignUp(dispatch, email, fullName, password) {
+  dispatch({ type: 'POST_SIGNUP' });
+  try {
+    const response = await postSignUpApi({
+      email: email,
+      fullName: fullName,
+      password: password,
+    });
+    dispatch({ type: 'POST_SIGNUP_SUCCESS', data: response.data.user });
+    return response;
+  } catch (e) {
+    dispatch({ type: 'POST_SIGNUP_ERROR', error: e });
+  }
+}
+
 // getUsersAPI 연동
 export async function getUsers(dispatch) {
   dispatch({ type: 'GET_USERS' });
@@ -119,12 +141,12 @@ export async function getUser(dispatch, id) {
 }
 
 // postLoginAPI 연동
-export async function postLogin(dispatch, formEmail, formPassword) {
+export async function postLogin(dispatch, email, password) {
   dispatch({ type: 'POST_LOGIN' });
   try {
     const response = await postLoginApi({
-      email: formEmail,
-      password: formPassword,
+      email: email,
+      password: password,
     });
     dispatch({ type: 'POST_LOGIN_SUCCESS', data: response.data.user });
     return response;

--- a/toronto/src/contexts/UserContext.js
+++ b/toronto/src/contexts/UserContext.js
@@ -4,13 +4,14 @@ import {
   getUserApi,
   postLoginApi,
   postUploadPhotoApi,
+  getAuthUser,
+  putUpdateUserApi,
+  postLogoutApi,
 } from '@/api/Api';
 import {
   createAsyncHandler,
   initialAsyncState,
 } from '@/utils/asyncActionUtils';
-import { getAuthUser, putUpdateUserApi } from '@/api/Api';
-//TODO: 로그아웃 시 쿠키 삭제
 
 const initialState = {
   users: initialAsyncState,
@@ -20,6 +21,7 @@ const initialState = {
 const usersHandler = createAsyncHandler('GET_USERS', 'users');
 const userHandler = createAsyncHandler('GET_USER', 'user');
 const loginHandler = createAsyncHandler('POST_LOGIN', 'user');
+const logoutHandler = createAsyncHandler('POST_LOGOUT', 'user');
 const authHandler = createAsyncHandler('GET_AUTH_USER', 'user');
 const updateHandler = createAsyncHandler('PUT_UPDATE_USER', 'user');
 const uploadProfileImageHandler = createAsyncHandler(
@@ -41,6 +43,10 @@ const usersReducer = (state, action) => {
     case 'POST_LOGIN_SUCCESS':
     case 'POST_LOGIN_ERROR':
       return loginHandler(state, action);
+    case 'POST_LOGOUT':
+    case 'POST_LOGOUT_SUCCESS':
+    case 'POST_LOGOUT_ERROR':
+      return logoutHandler(state, action);
     case 'GET_AUTH_USER':
     case 'GET_AUTH_USER_SUCCESS':
     case 'GET_AUTH_USER_ERROR':
@@ -124,6 +130,18 @@ export async function postLogin(dispatch, formEmail, formPassword) {
     return response;
   } catch (e) {
     dispatch({ type: 'POST_LOGIN_ERROR', error: e });
+  }
+}
+
+//postLogoutAPI 연동
+export async function postLogout(dispatch) {
+  dispatch({ type: 'POST_LOGOUT' });
+  try {
+    const response = await postLogoutApi();
+    dispatch({ type: 'POST_LOGOUT_SUCCESS', data: null });
+    return response;
+  } catch (e) {
+    dispatch({ type: 'POST_LOGOUT_ERROR', error: e });
   }
 }
 

--- a/toronto/src/contexts/UserContext.js
+++ b/toronto/src/contexts/UserContext.js
@@ -9,8 +9,7 @@ import {
   createAsyncHandler,
   initialAsyncState,
 } from '@/utils/asyncActionUtils';
-import { getAuthUser, putUpdateUserApi } from '../api/Api';
-//TODO: 새로고침해도 쿠키가 있을경우 로그인 상태로 유지, get auth  => cookie 동작
+import { getAuthUser, putUpdateUserApi } from '@/api/Api';
 //TODO: 로그아웃 시 쿠키 삭제
 
 const initialState = {
@@ -134,6 +133,7 @@ export async function getAuth(dispatch) {
   try {
     const response = await getAuthUser();
     dispatch({ type: 'GET_AUTH_USER_SUCCESS', data: response.data });
+    return response;
   } catch (e) {
     dispatch({ type: 'GET_AUTH_USER_ERROR', error: e });
   }

--- a/toronto/src/index.js
+++ b/toronto/src/index.js
@@ -5,9 +5,7 @@ import { BrowserRouter } from 'react-router-dom';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
-  <React.StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
-  </React.StrictMode>,
+  <BrowserRouter>
+    <App />
+  </BrowserRouter>,
 );

--- a/toronto/src/layout/Layout.jsx
+++ b/toronto/src/layout/Layout.jsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { Outlet, useNavigate } from 'react-router-dom';
 import Cookies from 'universal-cookie';
-import { StyledLink, Loader, Button } from '@components/atoms/';
+import { StyledLink, Loader, Button } from '@/components/atoms/';
 import {
   useUsersState,
   useUsersDispatch,

--- a/toronto/src/layout/Layout.jsx
+++ b/toronto/src/layout/Layout.jsx
@@ -1,22 +1,23 @@
-import { Outlet } from 'react-router-dom';
-import { StyledLink, Loader } from '@components/atoms/';
+import { useEffect } from 'react';
+import { Outlet, useNavigate } from 'react-router-dom';
+import Cookies from 'universal-cookie';
+import { StyledLink, Loader, Button } from '@components/atoms/';
 import {
   useUsersState,
   useUsersDispatch,
   getAuth,
+  postLogout,
 } from '@/contexts/UserContext.js';
 import { getToken } from '@/lib/Login.js';
-import { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
 
 const Layout = () => {
   const state = useUsersState();
   const dispatch = useUsersDispatch();
   const navigate = useNavigate();
   const { data: user, loading, error } = state.user;
+  const token = getToken();
   useEffect(() => {
     const fetchData = async () => {
-      const token = getToken();
       if (token) {
         await getAuth(dispatch);
       } else {
@@ -25,7 +26,16 @@ const Layout = () => {
     };
     fetchData();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [dispatch]);
+  }, []);
+
+  const handleLogout = async () => {
+    const response = await postLogout(dispatch);
+    if (response.statusText === 'OK') {
+      const cookies = new Cookies();
+      cookies.remove('USER_TOKEN');
+      navigate('/login');
+    }
+  };
 
   if (loading) return <Loader type='spinner' />;
   if (error) return <div>에러가 발생했습니다</div>;
@@ -44,14 +54,16 @@ const Layout = () => {
         </div>
       </div>
     );
-  } else {
+  } else if (user && token) {
     return (
       <div>
         <h1>토론토</h1>
         <nav>
           <StyledLink to='/'>Home</StyledLink> |
           <StyledLink to={user._id}>Profile</StyledLink> |
-          <StyledLink to='logout'>Logout</StyledLink> |
+          <StyledLink to={'/'}>
+            <Button onClick={handleLogout}>Logout</Button>
+          </StyledLink>
         </nav>
         <div className='content'>
           <Outlet />

--- a/toronto/src/layout/Layout.jsx
+++ b/toronto/src/layout/Layout.jsx
@@ -1,10 +1,31 @@
 import { Outlet } from 'react-router-dom';
 import { StyledLink, Loader } from '@components/atoms/';
-import { useUsersState } from '../contexts/UserContext.js';
+import {
+  useUsersState,
+  useUsersDispatch,
+  getAuth,
+} from '@/contexts/UserContext.js';
+import { getToken } from '@/lib/Login.js';
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 const Layout = () => {
   const state = useUsersState();
+  const dispatch = useUsersDispatch();
+  const navigate = useNavigate();
   const { data: user, loading, error } = state.user;
+  useEffect(() => {
+    const fetchData = async () => {
+      const token = getToken();
+      if (token) {
+        await getAuth(dispatch);
+      } else {
+        navigate('/login');
+      }
+    };
+    fetchData();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dispatch]);
 
   if (loading) return <Loader type='spinner' />;
   if (error) return <div>에러가 발생했습니다</div>;


### PR DESCRIPTION
## 📌 과제 설명
- Login 유지, Logout 기능 구현, SignUp API 연동 구현 완료했습니다!

## 👩‍💻 요구 사항과 구현 내용
[feat(auth): Login 유지 구현](https://github.com/prgrms-fe-devcourse/FEDC2_ToronTo_Nayoung/commit/6d17821dab8649a3416e8c99480ed78704f47e0f)
- 새로고침을 했을 때 토큰이 있는 경우 get-auth API를 사용해서 Context에 user 객체를 받아오도록 로그인 유지해뒀습니다.

[feat(Logout): Logout 기능 구현](https://github.com/prgrms-fe-devcourse/FEDC2_ToronTo_Nayoung/commit/cb8c6fd836d757db615c513bfbefd3b1247da8f9)
- logout 버튼을 누르면 Context에 있는 logout API 호출이 이뤄지고 성공할 경우 user 객체를 null로 만들고 쿠키에 있는 토큰을 삭제해줍니다.

[refactor(React.StrictMode): React.StrictMode 제거](https://github.com/prgrms-fe-devcourse/FEDC2_ToronTo_Nayoung/commit/aa4e3b5ac2d85bb61286beff15f03adfbfc2b711)
- render가 2번 되어 API호출이 반복되는 현상이 발생하여 StrictMode를 제거했습니다.

[feat(SignUp): SignUp API 연동 및 기능 구현](https://github.com/prgrms-fe-devcourse/FEDC2_ToronTo_Nayoung/commit/a466210518b1b677d43175f51efc878fde6dd6f1)
- SignUp API에 연동하여 회원가입을 할 경우 user객체를 Context에서 관리할 수 있게 구현했습니다.

[refactor(LoginForm): alias 적용 및 Loader 설정](https://github.com/prgrms-fe-devcourse/FEDC2_ToronTo_Nayoung/commit/7cffaa50e89aaf7863c9497513aab170ae884668)