### PR TITLE
[Components/Organisms] UserList 컴포넌트 구현

### DIFF
--- a/toronto/src/components/molecules/UserItem/index.js
+++ b/toronto/src/components/molecules/UserItem/index.js
@@ -1,0 +1,49 @@
+import StyledLink from '@/components/atoms/StyledLink';
+import Card from '@/components/atoms/Card';
+import Header from '@/components/atoms/Header';
+import Image from '@/components/atoms/Image';
+import styled from 'styled-components';
+
+const StyledLi = styled.li`
+  list-style: none;
+`;
+
+const UserContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const UserItem = ({ user }) => {
+  return (
+    <StyledLi>
+      <StyledLink to={`/${user._id}`} style={{ color: 'black' }}>
+        <Card
+          hover={true}
+          radius={5}
+          style={{ width: '100%', boxSizing: 'border-box', overflow: 'hidden' }}
+        >
+          <UserContainer>
+            <Image
+              src={user.image || 'https://via.placeholder.com/200'}
+              width={'100%'}
+              height={300}
+            ></Image>
+            <Header
+              level={3}
+              style={{
+                padding: 10,
+                textOverflow: 'ellipsis',
+                overflow: 'hidden',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {user.fullName}
+            </Header>
+          </UserContainer>
+        </Card>
+      </StyledLink>
+    </StyledLi>
+  );
+};
+
+export default UserItem;

--- a/toronto/src/components/organisms/UserList/index.js
+++ b/toronto/src/components/organisms/UserList/index.js
@@ -1,0 +1,13 @@
+import UserItem from '@/components/molecules/UserItem';
+
+const UserList = ({ users }) => {
+  return (
+    <>
+      {users.map((user) => (
+        <UserItem key={user._id} user={user} />
+      ))}
+    </>
+  );
+};
+
+export default UserList;

--- a/toronto/src/stories/components/molecules/UserItem.stories.js
+++ b/toronto/src/stories/components/molecules/UserItem.stories.js
@@ -1,0 +1,46 @@
+import UserItem from '@/components/molecules/UserItem';
+import { BrowserRouter } from 'react-router-dom';
+import styled from 'styled-components';
+
+export default {
+  title: 'Component/Molecules/UserItem',
+  component: UserItem,
+};
+
+const DUMMY_DATA = {
+  role: 'Regular',
+  emailVerified: false,
+  banned: false,
+  isOnline: false,
+  posts: [],
+  likes: [],
+  comments: [],
+  followers: [],
+  following: [],
+  notifications: [],
+  messages: [],
+  _id: '62a6c351f1f0277287103588',
+  fullName: 'JaeungE',
+  email: 'jaeunge@gmail.com',
+  createdAt: '2022-06-13T04:55:45.242Z',
+  updatedAt: '2022-06-17T15:04:34.586Z',
+  __v: 0,
+  image:
+    'https://res.cloudinary.com/learnprogrammers/image/upload/v1655130539/user/77541887-66f8-4c33-a59d-92cab0bcc9ad.jpg',
+  imagePublicId: 'user/77541887-66f8-4c33-a59d-92cab0bcc9ad',
+};
+
+const Wrapper = styled.div`
+  width: 400px;
+  height: 400px;
+`;
+
+export const Default = () => {
+  return (
+    <BrowserRouter>
+      <Wrapper>
+        <UserItem user={DUMMY_DATA} />
+      </Wrapper>
+    </BrowserRouter>
+  );
+};

--- a/toronto/src/stories/components/organisms/UserList.stories.js
+++ b/toronto/src/stories/components/organisms/UserList.stories.js
@@ -1,0 +1,49 @@
+import styled from 'styled-components';
+import UserList from '@/components/organisms/UserList';
+import { BrowserRouter } from 'react-router-dom';
+
+export default {
+  title: 'Component/Organisms/UserList',
+  component: UserList,
+};
+
+const GridContainer = styled.ul`
+  display: grid;
+  padding: 0;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  grid-template-rows: repeat(auto-fit, minmax(300px, 1fr));
+  grid-gap: 30px;
+`;
+
+const DUMMY_DATA = [
+  {
+    _id: '62a73eeb4ed95908dae3b37c',
+    fullName: '장규범',
+    image:
+      'https://res.cloudinary.com/learnprogrammers/image/upload/v1655395844/user/1363f15d-f8d4-41d6-86fd-c83c87b8fb06.jpg',
+  },
+  {
+    _id: '62a6c351f1f0277287103588',
+    fullName: 'JaeungE',
+    image:
+      'https://res.cloudinary.com/learnprogrammers/image/upload/v1655130539/user/77541887-66f8-4c33-a59d-92cab0bcc9ad.jpg',
+  },
+  {
+    _id: '62a6d331f1f02772871035d3',
+    fullName: '팽13',
+  },
+  {
+    _id: '62ad869ddd215b4a8c00684f',
+    fullName: '홍정기',
+  },
+];
+
+export const Default = () => {
+  return (
+    <BrowserRouter>
+      <GridContainer>
+        <UserList users={DUMMY_DATA} />
+      </GridContainer>
+    </BrowserRouter>
+  );
+};


### PR DESCRIPTION
## 구현 내용

`UserListPage`에서 사용할 `UserList` 컴포넌트 구현

## props

- **users**: 배열 형태의 `User` 객체

## Storybook
![image](https://user-images.githubusercontent.com/62253743/174430652-9853a010-b039-4e66-9d40-d4bdc370cea3.png)

## 리뷰 중점 내용
기존에 사용하던 `PostList` 컴포넌트와 기능적으로 큰 차이가 없습니다. `UserItem`과 마찬가지로 한 분만 확인해주시면 바로 merge 하도록 하겠습니다.