### PR TITLE
[Pages/UserListPage] UserListPage 구현

### DIFF
--- a/toronto/src/App.js
+++ b/toronto/src/App.js
@@ -11,6 +11,7 @@ import {
   EditProfilePage,
 } from '@pages';
 import UsersProvider from './contexts/UserContext';
+import UserListPage from './pages/UserListPage';
 
 function App() {
   return (
@@ -24,6 +25,7 @@ function App() {
           <Route path='/:userId/edit' element={<EditProfilePage />} />
           <Route path='/login' element={<Login />} />
           <Route path='/sign-up' element={<SignUp />} />
+          <Route path='/user/list' element={<UserListPage />} />
         </Route>
         <Route path='*' element={<NotFoundPage />} />
       </Routes>

--- a/toronto/src/components/molecules/UserItem/index.js
+++ b/toronto/src/components/molecules/UserItem/index.js
@@ -16,7 +16,7 @@ const UserContainer = styled.div`
 const UserItem = ({ user }) => {
   return (
     <StyledLi>
-      <StyledLink to={`/${user._id}`} style={{ color: 'black' }}>
+      <StyledLink to={`/users/${user._id}`} style={{ color: 'black' }}>
         <Card
           hover={true}
           radius={5}

--- a/toronto/src/pages/UserListPage.jsx
+++ b/toronto/src/pages/UserListPage.jsx
@@ -90,7 +90,7 @@ const GridContainer = styled.ul`
   padding: 0;
   grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
   grid-template-rows: repeat(auto-fit, minmax(300px, 1fr));
-  grid-auto-rows: 300px;
-  grid-auto-columns: 300px;
-  grid-gap: 30px;
+  grid-auto-rows: minmax(300, 1fr);
+  grid-auto-columns: minmax(300, 1fr);
+  gap: 30px;
 `;

--- a/toronto/src/pages/UserListPage.jsx
+++ b/toronto/src/pages/UserListPage.jsx
@@ -1,0 +1,96 @@
+import UserList from '@/components/organisms/UserList';
+import { useCallback, useEffect, useState } from 'react';
+import styled from 'styled-components';
+import InputBar from '@/components/molecules/InputBar';
+import axios from 'axios';
+import Skeleton from '@/components/atoms/Skeleton';
+
+const renderSkeleton = () => {
+  const skeletons = [];
+
+  for (let i = 0; i < 10; i++) {
+    skeletons.push(<Skeleton.Box key={i} width={'100%'} height={'100%'} />);
+  }
+
+  return skeletons;
+};
+
+const UserListPage = () => {
+  const [users, setUsers] = useState([]);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const initialUsers = useCallback(async () => {
+    setIsLoading(true);
+
+    const res = await axios.get(
+      `${process.env.REACT_APP_END_POINT}/users/get-users`,
+    );
+
+    setUsers([...res.data]);
+    setIsLoading(false);
+  }, []);
+
+  useEffect(() => {
+    initialUsers();
+  }, [initialUsers]);
+
+  const handleSubmit = useCallback(
+    async (value) => {
+      if (!value) {
+        initialUsers();
+        return;
+      }
+
+      setIsLoading(true);
+
+      const res = await axios.get(
+        `${process.env.REACT_APP_END_POINT}/search/users/${value}`,
+      );
+
+      setUsers([...res.data]);
+      setIsLoading(false);
+    },
+    [initialUsers],
+  );
+
+  return (
+    <Container>
+      <Wrapper>
+        <InputBar
+          placeholder={'유저 검색'}
+          buttonType={'inside'}
+          onSubmit={(value) => handleSubmit(value)}
+        />
+      </Wrapper>
+      <GridContainer>
+        <UserList users={users} />
+        {isLoading ? renderSkeleton() : undefined}
+      </GridContainer>
+    </Container>
+  );
+};
+
+export default UserListPage;
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 80%;
+  height: 100%;
+  margin: 0 auto;
+`;
+
+const Wrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;
+
+const GridContainer = styled.ul`
+  display: grid;
+  padding: 0;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  grid-template-rows: repeat(auto-fit, minmax(300px, 1fr));
+  grid-auto-rows: 300px;
+  grid-auto-columns: 300px;
+  grid-gap: 30px;
+`;

--- a/toronto/src/pages/UserListPage.jsx
+++ b/toronto/src/pages/UserListPage.jsx
@@ -64,7 +64,7 @@ const UserListPage = () => {
       </Wrapper>
       <GridContainer>
         <UserList users={users} />
-        {isLoading ? renderSkeleton() : undefined}
+        {isLoading && renderSkeleton()}
       </GridContainer>
     </Container>
   );
@@ -90,7 +90,7 @@ const GridContainer = styled.ul`
   padding: 0;
   grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
   grid-template-rows: repeat(auto-fit, minmax(300px, 1fr));
-  grid-auto-rows: minmax(300, 1fr);
-  grid-auto-columns: minmax(300, 1fr);
+  grid-auto-rows: minmax(300px, 1fr);
+  grid-auto-columns: minmax(300px, 1fr);
   gap: 30px;
 `;


### PR DESCRIPTION
## 구현 내용

사용자 목록을 확인할 수 있는 페이지 및 검색 기능 구현

<br>

## UI
![UserListPage (1)](https://user-images.githubusercontent.com/62253743/174448251-89f3ae34-9985-4259-a284-ef29c46e2ccd.gif)

<br>

## 리뷰 중점 내용

완성된 `Home Page` 기반으로 `UserListPage`를 구현하였습니다.

`User` 목록 조회 `API`는 `Users` 배열에 대한 전체 길이를 알 수 없기 때문에 `offset`으로 처리할 수 없어서(사용자 측면에서 '더 보기' 기능 구현이 가능하지만, `data` 자체는 통채로 넘겨받아야 함) 초기 페이지 진입 시 모든 데이터를 출력하도록 했습니다.

검색 기능은 `User` 객체의 `fullName`을 기준으로 검색하며, `input` 값이 없는 상태로 검색하게 되면 페이지 초기 진입과 동일한 동작을 합니다.

또한 라우팅 처리는  추후 리팩토링 시 `url`을 일치시키면 될 것 같습니다!