### PR TITLE
[Components/Molecules] PostItem 기능 및 디자인 수정

### DIFF
--- a/toronto/src/components/molecules/PostItem/index.js
+++ b/toronto/src/components/molecules/PostItem/index.js
@@ -4,7 +4,9 @@ import Header from '@/components/atoms/Header';
 import Image from '@/components/atoms/Image';
 import Text from '@/components/atoms/Text';
 import styled from 'styled-components';
-// import { useUsersState } from '@/contexts/UserContext';
+import { useUsersState } from '@/contexts/UserContext';
+import { useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 const StyledLi = styled.li`
   list-style: none;
@@ -28,11 +30,23 @@ const ContentContainer = styled.div`
 `;
 
 const PostItem = ({ post }) => {
-  // const state = useUsersState();
-  // const { data: user } = state.user;
-  // const userId = user?._id;
-  const { _id: postId, image } = post;
+  const state = useUsersState();
+  const navigate = useNavigate();
+  const { data: user } = state.user;
+  const userId = user?._id;
+  const { _id: postId, image, comments } = post;
   const { postTitle, postContent } = JSON.parse(post.title);
+  const isVoted = comments.some((comment) => comment.author?._id === userId);
+
+  const handleClick = useCallback(
+    (e) => {
+      if (userId && isVoted) {
+        e.preventDefault();
+        navigate(`/controversy/result/${postId}`);
+      }
+    },
+    [isVoted, userId, postId, navigate],
+  );
 
   return (
     <StyledLi>
@@ -55,7 +69,11 @@ const PostItem = ({ post }) => {
               {postTitle}
             </Header>
           </TitleContainer>
-          <StyledLink to={`/controversy/${postId}`} style={{ color: 'black' }}>
+          <StyledLink
+            to={`/controversy/${postId}`}
+            onClick={handleClick}
+            style={{ color: 'black' }}
+          >
             <ContentContainer>
               <Image
                 src={image || 'https://via.placeholder.com/200'}

--- a/toronto/src/components/molecules/PostItem/index.js
+++ b/toronto/src/components/molecules/PostItem/index.js
@@ -1,8 +1,4 @@
-import StyledLink from '@/components/atoms/StyledLink';
-import Card from '@/components/atoms/Card';
-import Header from '@/components/atoms/Header';
-import Image from '@/components/atoms/Image';
-import Text from '@/components/atoms/Text';
+import { StyledLink, Card, Header, Image, Text } from '@/components/atoms';
 import styled from 'styled-components';
 import { useUsersState } from '@/contexts/UserContext';
 import { useCallback } from 'react';

--- a/toronto/src/components/molecules/PostItem/index.js
+++ b/toronto/src/components/molecules/PostItem/index.js
@@ -3,13 +3,8 @@ import Card from '@/components/atoms/Card';
 import Header from '@/components/atoms/Header';
 import Image from '@/components/atoms/Image';
 import Text from '@/components/atoms/Text';
-import Icon from '@/components/atoms/Icon';
-import Loader from '@/components/atoms/Loader';
-import axios from 'axios';
 import styled from 'styled-components';
-import { useState } from 'react';
-import { useUsersState } from '@/contexts/UserContext';
-import { getToken } from '@/lib/Login';
+// import { useUsersState } from '@/contexts/UserContext';
 
 const StyledLi = styled.li`
   list-style: none;
@@ -32,65 +27,12 @@ const ContentContainer = styled.div`
   flex-direction: column;
 `;
 
-const StyledButton = styled.button`
-  border: none;
-  background-color: transparent;
-  cursor: pointer;
-  padding: 0;
-
-  &:hover {
-    transform: scale(1.2);
-  }
-`;
-
 const PostItem = ({ post }) => {
-  const state = useUsersState();
-  const { data: user } = state.user;
-  const userId = user?._id;
-  const { _id: postId, image, likes } = post;
+  // const state = useUsersState();
+  // const { data: user } = state.user;
+  // const userId = user?._id;
+  const { _id: postId, image } = post;
   const { postTitle, postContent } = JSON.parse(post.title);
-  const like = likes
-    ? likes.filter(({ user }) => user === userId)[0]
-    : undefined;
-  const [isLike, setIsLike] = useState(Boolean(like));
-  const [isLoading, setIsLoading] = useState(false);
-  const [likeId, setLikeId] = useState(like?._id);
-
-  const handleClick = async () => {
-    if (!userId) {
-      alert('좋아요는 로그인 한 사용자만 누를 수 있습니다.');
-      return;
-    }
-    setIsLoading(true);
-
-    if (!isLike) {
-      const res = await axios.post(
-        `${process.env.REACT_APP_END_POINT}/likes/create`,
-        {
-          postId: postId,
-        },
-        {
-          headers: {
-            Authorization: `bearer ${getToken()}`,
-          },
-        },
-      );
-
-      setLikeId(res.data._id);
-    } else {
-      await axios.delete(`${process.env.REACT_APP_END_POINT}/likes/delete`, {
-        headers: {
-          Authorization: `bearer ${getToken()}`,
-        },
-        data: {
-          id: likeId,
-        },
-      });
-    }
-
-    setIsLike((like) => !like);
-    setIsLoading(false);
-  };
 
   return (
     <StyledLi>
@@ -112,21 +54,6 @@ const PostItem = ({ post }) => {
             >
               {postTitle}
             </Header>
-            {!isLoading ? (
-              <StyledButton onClick={handleClick}>
-                {isLike ? (
-                  <Icon
-                    iconName={'thumbs-up'}
-                    strokeWidth={1.5}
-                    fill={'#2366F6'}
-                  />
-                ) : (
-                  <Icon iconName={'thumbs-up'} strokeWidth={1.5} />
-                )}
-              </StyledButton>
-            ) : (
-              <Loader size={24} loading={isLoading} />
-            )}
           </TitleContainer>
           <StyledLink to={`/controversy/${postId}`} style={{ color: 'black' }}>
             <ContentContainer>

--- a/toronto/src/components/molecules/PostItem/index.js
+++ b/toronto/src/components/molecules/PostItem/index.js
@@ -12,17 +12,7 @@ const PostContainer = styled.div`
   display: flex;
   flex-direction: column;
   width: 100%;
-`;
-
-const TitleContainer = styled.div`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-`;
-
-const ContentContainer = styled.div`
-  display: flex;
-  flex-direction: column;
+  max-height: 300px;
 `;
 
 const PostItem = ({ post }) => {
@@ -46,44 +36,49 @@ const PostItem = ({ post }) => {
 
   return (
     <StyledLi>
-      <Card
-        padding={10}
-        hover={true}
-        radius={5}
-        style={{ width: '100%', boxSizing: 'border-box' }}
+      <StyledLink
+        to={`/controversy/${postId}`}
+        onClick={handleClick}
+        style={{ color: 'black' }}
       >
-        <PostContainer>
-          <TitleContainer>
+        <Card
+          padding={10}
+          hover={true}
+          radius={5}
+          style={{ width: '100%', boxSizing: 'border-box' }}
+        >
+          <PostContainer>
             <Header
               level={3}
               style={{
                 textOverflow: 'ellipsis',
                 overflow: 'hidden',
                 whiteSpace: 'nowrap',
+                flexShrink: 0,
               }}
             >
               {postTitle}
             </Header>
-          </TitleContainer>
-          <StyledLink
-            to={`/controversy/${postId}`}
-            onClick={handleClick}
-            style={{ color: 'black' }}
-          >
-            <ContentContainer>
-              <Image
-                src={image || 'https://via.placeholder.com/200'}
-                width={'100%'}
-                height={200}
-                mode={'cover'}
-              />
-              <Text size='normal' style={{ paddingTop: 20 }}>
-                {postContent}
-              </Text>
-            </ContentContainer>
-          </StyledLink>
-        </PostContainer>
-      </Card>
+            <Image
+              src={image || 'https://via.placeholder.com/200'}
+              width={'100%'}
+              height={200}
+              mode={'cover'}
+            />
+            <Text
+              size='normal'
+              style={{
+                paddingTop: 20,
+                textOverflow: 'ellipsis',
+                overflow: 'hidden',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {postContent}
+            </Text>
+          </PostContainer>
+        </Card>
+      </StyledLink>
     </StyledLi>
   );
 };

--- a/toronto/src/components/molecules/PostItem/index.js
+++ b/toronto/src/components/molecules/PostItem/index.js
@@ -63,7 +63,6 @@ const PostItem = ({ post }) => {
               src={image || 'https://via.placeholder.com/200'}
               width={'100%'}
               height={200}
-              mode={'cover'}
             />
             <Text
               size='normal'


### PR DESCRIPTION
## 구현 내용

- 기존에 구현되어있던 좋아요 및 취소 기능 삭제
- 모듈 `import` 정리
- 이미 투표한 기록이 있다면 결과 페이지로 이동하도록 처리
- 디자인 수정

## UI
![PostItem](https://user-images.githubusercontent.com/62253743/174556475-74c4cf80-c1f1-477b-9a5e-bf9577047d42.gif)

## 리뷰 중점 내용
현재 로컬 브랜치에는 `PR`에 올려져 있는 내용이 반영되어 있지 않아서 유저 프로필에서도 정상적으로 동작하는지는 확인하지 못 했습니다.

같은 컴포넌트를 사용하기 때문에 문제는 없을 것으로 예상되지만, 혹시라도 합치고 나서 추후 문제가 생기면 바로 수정하도록 하겠습니다!
